### PR TITLE
Add HTTPProxy Sample Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ backends that are selected by subcommands.
 ## Key Features:
 - **Multi-Tenancy Support**: One of the standout features of contour-auth-multi-tenant is its built-in support for multi-tenancy. This allows us to securely manage and isolate authorization scopes for different tenants within a single instance.
 
-- **Enhanced Performance**: 
-contour-auth-multi-tenant has meticulously been optimized to deliver outstanding performance under heavy loads. This ensures that your application's authorization layer can handle requests efficiently, without introducing bottlenecks or delays.
+- **Enhanced Performance**: contour-auth-multi-tenant has meticulously been optimized to deliver outstanding performance under heavy loads. This ensures that your application's authorization layer can handle requests efficiently, without introducing bottlenecks or delays.
 
 # htpasswd
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ backends that are selected by subcommands.
 
 `contour-auth-multi-tenant` adds multi-tenancy feature to `contour-authserver` and improves its performance to make it production-ready.
 
-Key Features:
-- Multi-Tenancy Support: One of the standout features of contour-auth-multi-tenant is its built-in support for multi-tenancy. This allows us to securely manage and isolate authorization scopes for different tenants within a single instance.
+## Key Features:
+- **Multi-Tenancy Support**: One of the standout features of contour-auth-multi-tenant is its built-in support for multi-tenancy. This allows us to securely manage and isolate authorization scopes for different tenants within a single instance.
 
-- Enhanced Performance: We have meticulously optimized contour-auth-multi-tenant to deliver outstanding performance under heavy loads. This ensures that your application's authorization layer can handle requests efficiently, without introducing bottlenecks or delays.
+- **Enhanced Performance**: 
+contour-auth-multi-tenant has meticulously been optimized to deliver outstanding performance under heavy loads. This ensures that your application's authorization layer can handle requests efficiently, without introducing bottlenecks or delays.
 
 # htpasswd
 
@@ -68,6 +69,48 @@ used to further restrict which Secrets the `htpasswd` backend will consume. (Use
 While `contour-authserver` matches the provided credential in the `Authorization` header against all the Secrets, `contour-auth-multi-tenant` offers a more refined approach. It matches the provided credential against a user-defined Secret, enabling precise control over authorization scopes.
 
 To leverage the multi-tenancy feature of `contour-auth-multi-tenant`, include a secret reference in your Envoy [CheckRequest](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#service-auth-v3-checkrequest). Specify the reference in the request's context, using `secretRef` as the key and the `namespace/secretName` format for the value.
+
+Here is a sample HTTPProxy instance in which htpasswd is supported. Please notice that defining an `authPolicy` is a necessity in order to be able to use the specified secret. 
+
+example:
+```
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: SAMPLE_NAME
+  namespace: SAMPLE_NAMESPACE
+spec:
+  ingressClassName: INGRESS_CLASS_NAME
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: SERVICE_NAME
+          port: 80
+  virtualhost:
+    authorization:
+      authPolicy:
+        context:
+          secretRef: NAMESPACE/SECRET_NAME
+      extensionRef:
+        name: EXTENSION_SERVICE_NAME
+        namespace: EXTENSION_SERVICE_NAMESPACE
+    fqdn: SAMPLE_FQDN
+    tls:
+      enableFallbackCertificate: false
+      secretName: NAMESPACE/TLS_CERT_NAME
+```
+The ExtensionService does not necessarily need to be in the same namespace as the configuration provides the namespace option.
+It has been supposed that the service listens on root path `/` and port `80`. 
+
+### htpasswd Secret Configuration
+It is important to note that the procedure of matching Secrets occures by comparing the existing Secrets' labels with Contour Authserver's secretSelector. In addition, it is worth mentioning that the key `auth` should be present while using the label. 
+The default value for secretSelector is `auth.contour.snappcloud.io/type=basic` which can be modified to a desirable one following the mentioned format. 
+
+example:
+```
+auth.contour.sample.label/type=basic
+```
 
 # OIDC
 


### PR DESCRIPTION
Dear Cloud Team,

Some changes have been made to this fabulous repository's README.md in order to ease the process of testing Contour Authserver's Multi-Tenant feature by providing a readily-available HTTPProxy configuration as well as some explanation about the Secret's labels.
It would be grate if you could take a look at the applied changes.

Best,
Rojin